### PR TITLE
[ch59902] raise error when a required field is an empty list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,9 @@ cython_debug/
 
 # VSCode
 .vscode/*
+
+# Mac
+.DS_Store
+
+#IDE
+.idea/*

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repo contains reusable code to help develop DSS plugins.
 
 ## Included libs
 
-- [dku_config](https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/dku_config) (Last update: 2021-28-01): Gives the ability to check forms parameters in backend and to display understandable messages if fails.
-- [nlp](https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/nlp): Detect languages, tokenize, correct misspellings and clean text data.
+- [dku_config](https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/dku_config): Gives the ability to check forms parameters in backend and to display understandable messages if fails
+- [nlp](https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/nlp): Detect languages, tokenize, correct misspellings and clean text data
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repo contains reusable code to help develop DSS plugins.
 
 ## Included libs
 
-- [dku_config](https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/dku_config): Gives the ability to check forms parameters in backend and to display understandable messages if fails
-- [nlp](https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/nlp): Detect languages, tokenize, correct misspellings and clean text data
+- [dku_config](https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/dku_config) (Last update: 2021-28-01): Gives the ability to check forms parameters in backend and to display understandable messages if fails.
+- [nlp](https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/nlp): Detect languages, tokenize, correct misspellings and clean text data.
 
 ## License
 

--- a/dkulib/dku_config/README.md
+++ b/dkulib/dku_config/README.md
@@ -86,7 +86,7 @@ Don't hesitate to check these plugins using the library for more examples :
 
 ## Version
 
-- Version: 0.1.1
+- Version: 0.1.2
 - State: <span style="color:green">Supported</span>
 
 ## Credit

--- a/dkulib/dku_config/__init__.py
+++ b/dkulib/dku_config/__init__.py
@@ -1,9 +1,9 @@
 ########################################################
-# ------------- dkulib.dku_config: 0.1.1 ----------------
+# ------------- dkulib.dku_config: 0.1.2 ----------------
 
 # For more information, see https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/dku_config
-# Library version: 0.1.1
-# Last update: 2020-12-29
+# Library version: 0.1.2
+# Last update: 2021-01-28
 # Author: Dataiku (Henri Chabert)
 #########################################################
 

--- a/dkulib/dku_config/custom_check.py
+++ b/dkulib/dku_config/custom_check.py
@@ -109,7 +109,8 @@ class CustomCheck:
         Returns:
             bool: Whether the check has succeed
         """
-        return value is not None and value != []
+        EMPTY_ENTRIES = [[], "", None]
+        return value not in EMPTY_ENTRIES
 
     def _in(self, value: Any) -> bool:
         """Checks whether the value is in the iterable given in "op" attribute

--- a/dkulib/dku_config/custom_check.py
+++ b/dkulib/dku_config/custom_check.py
@@ -109,7 +109,7 @@ class CustomCheck:
         Returns:
             bool: Whether the check has succeed
         """
-        return value is not None
+        return value is not None and value != []
 
     def _in(self, value: Any) -> bool:
         """Checks whether the value is in the iterable given in "op" attribute

--- a/tests/dku_config/test_custom_check.py
+++ b/tests/dku_config/test_custom_check.py
@@ -20,7 +20,8 @@ class TestCustomCheck:
         )
         assert custom_check.run('test') is None
         assert custom_check.run('') is None
-        assert custom_check.run([]) is None
+        with pytest.raises(CustomCheckError):
+            _ = custom_check.run([])
         with pytest.raises(CustomCheckError):
             _ = custom_check.run(None)
 

--- a/tests/dku_config/test_custom_check.py
+++ b/tests/dku_config/test_custom_check.py
@@ -19,7 +19,8 @@ class TestCustomCheck:
             type='exists'
         )
         assert custom_check.run('test') is None
-        assert custom_check.run('') is None
+        with pytest.raises(CustomCheckError):
+            _ = custom_check.run('')
         with pytest.raises(CustomCheckError):
             _ = custom_check.run([])
         with pytest.raises(CustomCheckError):


### PR DESCRIPTION
[[ch59902]](https://app.clubhouse.io/dataiku/story/59902/custom-check-when-a-field-is-required-and-its-value-is-an-empty-list-dku-config-should-raise-an-error)

When a field is required, it should not be an empty list. In this PR : 
- I changed the custom check `_exist`
- I changed the unit test accordingly