### PR TITLE
Update error messages consistently with Krishna's advice

### DIFF
--- a/dkulib/dku_config/README.md
+++ b/dkulib/dku_config/README.md
@@ -86,7 +86,7 @@ Don't hesitate to check these plugins using the library for more examples :
 
 ## Version
 
-- Version: 0.1.2
+- Version: 0.1.3
 - State: <span style="color:green">Supported</span>
 
 ## Credit

--- a/dkulib/dku_config/__init__.py
+++ b/dkulib/dku_config/__init__.py
@@ -1,9 +1,9 @@
 ########################################################
-# ------------- dkulib.dku_config: 0.1.2 ----------------
+# ------------- dkulib.dku_config: 0.1.3 ----------------
 
 # For more information, see https://github.com/dataiku/dss-plugin-dkulib/tree/main/dkulib/dku_config
-# Library version: 0.1.2
-# Last update: 2021-01-28
+# Library version: 0.1.3
+# Last update: 2021-02-15
 # Author: Dataiku (Henri Chabert)
 #########################################################
 

--- a/dkulib/dku_config/custom_check.py
+++ b/dkulib/dku_config/custom_check.py
@@ -6,15 +6,15 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_ERROR_MESSAGES = {
     'exists': 'This field is required.',
-    'in': 'Should be in the following iterable: {op}.',
+    'in': 'Expected keys are: {op}.',
     'not_in': 'Should not be in the following iterable: {op}.',
     'eq': 'Should be equal to {op} (Currently {value}).',
-    'sup': 'Should be superior to {op} (Currently {value}).',
-    'sup_eq': 'Should be superior or equal to {op} (Currently {value}).',
-    'inf': 'Should be inferior to {op} (Currently {value}).',
-    'inf_eq': 'Should be inferior or equal to {op} (Currently {value}).',
-    'between': 'Should be between {op[0]} and {op[1]} (Currently {value}).',
-    'between_strict': 'Should be strictly between {op[0]} and {op[1]} (Currently {value}).',
+    'sup': 'Should be greater than {op} (Currently {value}).',
+    'sup_eq': 'Should be greater than or equal to {op} (Currently {value}).',
+    'inf': 'Should be less than {op} (Currently {value}).',
+    'inf_eq': 'Should be less than or equal to {op} (Currently {value}).',
+    'between': 'Should be between {op[0]} and {op[1]} inclusive (Currently {value}).',
+    'between_strict': 'Should be between {op[0]} and {op[1]} exclusive (Currently {value}).',
     'is_type': 'Should be of type {op}.',
     'custom': "There has been an unknown error."
 }

--- a/tests/dku_config/test_dss_parameter.py
+++ b/tests/dku_config/test_dss_parameter.py
@@ -58,7 +58,7 @@ class TestDSSParameter:
                     "op": 2
                 }]
             )
-            assert 'Error for parameter' in err
+        assert 'Error for parameter' in str(err.value)
 
     def test_double_failure(self, caplog):
         caplog.set_level(logging.INFO)
@@ -72,6 +72,7 @@ class TestDSSParameter:
                 }],
                 required=True
             )
-            assert 'Error for parameter' in err
-            assert 'required' in err
-            assert 'inferior' not in err
+        error_message = str(err.value)
+        assert 'Error for parameter' in error_message
+        assert 'required' not in error_message
+        assert 'less' in error_message


### PR DESCRIPTION
[[ch61047]](https://app.clubhouse.io/dataiku/story/61047/update-the-error-messages-based-on-krishna-s-advice)

I changed some default error messages to make the most of[ Krishna's advice](https://github.com/dataiku/dss-plugin-timeseries-preparation/pull/13) on error messages 
In `test_dss_parameters.py`, I also noted that the `assert` functions within the scope of `with pytest.raises(DSSParameterError)` did not work as expected. I guess it's because an error is already raised by  `DSSParameter` so it's not really checked. That's why I removed them from this scope. 