### PR TITLE
Generalize rows to batches

### DIFF
--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 """Apply a function to a pandas DataFrame with parallelization, error logging and progress tracking"""
 
-import inspect, logging, math
+import logging
+import inspect
+import math
 
 from typing import Callable, AnyStr, Any, List, Tuple, NamedTuple, Dict, Union, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -14,7 +16,7 @@ import pandas as pd
 from more_itertools import chunked, flatten
 from tqdm.auto import tqdm as tqdm_auto
 
-from plugin_io_utils import generate_unique
+from dkulib.io_utils.plugin_io_utils import generate_unique
 
 class ErrorHandling(Enum):
     """Enum class to identify how to handle API errors"""

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -48,6 +48,7 @@ def _parse_batch_response_default(batch: List[Dict],
         response: Response returned by the API, typically a JSON string
         output_column_names: Column names to be added to the row, 
             as defined in _get_unique_output_column_names
+
     Returns:
         batch: Same as input batch with additional columns 
             corresponding to the default output columns
@@ -62,7 +63,9 @@ def _parse_batch_response_default(batch: List[Dict],
 
 class DataFrameParallelizer:
     """Apply a function to a pandas DataFrame with parallelization, error logging and progress tracking.
+    
     This class is particularly well-suited for synchronous functions calling an API, either row-by-row or by batch.
+    
     Attributes:
         function: Any function taking a dict as input (row-by-row mode) or a list of dict (batch mode),
             and returning a response with additional information, typically a JSON string.
@@ -222,19 +225,23 @@ class DataFrameParallelizer:
         return output_df
 
     def run(self, df: pd.DataFrame, **function_kwargs,) -> pd.DataFrame:
-        """Apply a function to a pandas.DataFrame with parallelization, error logging and progress tracking
+        """Apply a function to a pandas.DataFrame with parallelization, error logging and progress tracking.
+        
         The DataFrame is iterated on and fed to the function as dictionaries, row-by-row or by batches of rows.
         This process is accelerated by the use of concurrent threads and is tracked with a progress bar.
         Errors are catched if they match the `self.exceptions_to_catch` attribute and automatically logged.
         Once the whole DataFrame has been iterated on, results and errors are added as additional columns.
+        
         Args:
             df: Input dataframe on which the function will be applied
             **function_kwargs: Arbitrary keyword arguments passed to the `function`
+
         Returns:
             Input dataframe with additional columns:
             - response from the `function`
             - error message if any
             - error type if any
+
         """
         # First, we create a generator expression to yield each row of the input dataframe.
         # Each row will be represented as a dictionary like {"column_name_1": "foo", "column_name_2": 42}

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -143,10 +143,10 @@ class DataFrameParallelizer:
         self.parallel_workers = parallel_workers
         self.batch_support = batch_support
         if batch_support is False:
+            # Overwrite necessary args for row-by-row iteration
             batch_size = 1
-            if batch_response_parser != _parse_batch_response_default:
-                raise ValueError("The default batch response parser "
-                                 + "should be used when batch_support is False.")
+            batch_response_parser = _parse_batch_response_default
+            
         self.batch_size = batch_size
         self.batch_response_parser = batch_response_parser
         self.output_column_prefix = output_column_prefix

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -187,7 +187,7 @@ class DataFrameParallelizer:
                     for row in output
                     if row[self._output_column_names.error_message]
                 ]
-            if errors:
+            if errors and self.batch_support:
                 raise BatchError(str(errors))
         except self.exceptions_to_catch + (BatchError,) as error:
             if self.error_handling == ErrorHandling.FAIL:

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -42,7 +42,7 @@ class BatchError(ValueError):
 
 def _parse_batch_response_default(batch: List[Dict],
                                   response: Any,
-                                  output_column_names: NamedTuple):
+                                  output_column_names: NamedTuple) -> List[Dict]:
     """Adds the response column to the row dictionary at batch[0], while keeping the 
     existing dict entries. Should only be used when batch_size=1.
 

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -144,8 +144,9 @@ class DataFrameParallelizer:
         self.batch_support = batch_support
         if batch_support is False:
             batch_size = 1
-            assert batch_response_parser == _parse_batch_response_default, "The default batch response parser " \
-                + "should be used when batch_support is False."
+            if batch_response_parser != _parse_batch_response_default:
+                raise ValueError("The default batch response parser "
+                                 + "should be used when batch_support is False.")
         self.batch_size = batch_size
         self.batch_response_parser = batch_response_parser
         self.output_column_prefix = output_column_prefix

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -180,7 +180,7 @@ class DataFrameParallelizer:
             for output_row in output:
                 output_row[output_column] = ""
         try:
-            if self.batch_support is False:
+            if not self.batch_support:
                 # In the row-by-row case, there is only one element in the list as batch_size=1
                 response = (
                     self.function(row=batch[0], **function_kwargs)

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 """Apply a function to a pandas DataFrame with parallelization, error logging and progress tracking"""
 
-import logging
-import inspect
-import math
+import inspect, logging, math
 
 from typing import Callable, AnyStr, Any, List, Tuple, NamedTuple, Dict, Union, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -16,8 +14,7 @@ import pandas as pd
 from more_itertools import chunked, flatten
 from tqdm.auto import tqdm as tqdm_auto
 
-from dkulib.io_utils.plugin_io_utils import generate_unique
-
+from plugin_io_utils import generate_unique
 
 class ErrorHandling(Enum):
     """Enum class to identify how to handle API errors"""
@@ -32,13 +29,11 @@ class BatchError(ValueError):
 
 class DataFrameParallelizer:
     """Apply a function to a pandas DataFrame with parallelization, error logging and progress tracking.
-
-    This class is particularly well-suited for synchronous functions calling an API, either row-by-row or by batch.
-
+    This class is particularly well-suited for synchronous functions calling an API, by batch.
     Attributes:
-        function: Any function taking a dict as input (row-by-row mode) or a list of dict (batch mode),
-            and returning a response with additional information, typically a JSON string.
-            In batch mode, the response from the function should be parsable by the `batch_response_parser` attribute.
+        function: Any function taking a list of dicts as input to a batch keyword argument and returning a response with 
+            additional information, typically a JSON string. If batch_size=1, the row can just be extracted with batch[0].
+            The response from the function should be parsable by the `batch_response_parser` attribute.
         error_handling: If ErrorHandling.LOG (default), log the error from the function as a warning,
             and add additional columns to the dataframe with the error message and error type.
             If ErrorHandling.FAIL, the function will fail is there is any error.
@@ -47,16 +42,12 @@ class DataFrameParallelizer:
             Mandatory if ErrorHandling.LOG (default).
         parallel_workers: Number of concurrent threads to parallelize the function. Default is 4.
             We recommend letting the end user tune this parameter to get better performance.
-        batch_support: If True, send batches of row (list of dict) to the `function`
-            Else (default) send rows as dict to the function.
-            This parameter should be chosen according to the nature of the function to apply.
-        batch_size: Number of rows to include in each batch. Default is 10.
-            Taken into account if `batch_support` is True.
+        batch_size: Number of rows to process at once. Default is 1, i.e. function is applied to each row individually.
             We recommend letting the end user tune this parameter if they need to increase performance.
-        batch_response_parser: Function used to parse the raw response from the function in batch mode,
+        batch_response_parser: Function used to parse the raw response from the function,
             and assign the actual responses and errors back to the original batch of row (list of dict).
+            Default is just the identity function, i.e. the function response is left unchanged.
             This is often required for batch APIs which return nested objects with a mix of responses and errors.
-            This parameter is required if batch_support is True.
         output_column_prefix: Column prefix to add to the output columns of the dataframe,
             containing the `function` responses and errors. Default is "output".
             This should be overriden by the developer: if the function to apply calls an API for text translation,
@@ -64,15 +55,14 @@ class DataFrameParallelizer:
         verbose: If True, log raw details on any error encountered along with the error message and error type.
             Else (default) log only the error message and the error type.
             We recommend trying without verbose first. Usually, the error message is enough to diagnose the issue.
-
     """
 
     DEFAULT_PARALLEL_WORKERS = 4
     """Default number of worker threads to use in parallel - may be tuned by the end user"""
-    DEFAULT_BATCH_SUPPORT = False
-    """By default, we assume the function to apply is row-by-row - should be overriden in the batch case"""
-    DEFAULT_BATCH_SIZE = 10
+    DEFAULT_BATCH_SIZE = 1
     """Default number of rows in one batch - may be tuned by the end user"""
+    DEFAULT_RESPONSE_PARSER = lambda batch, response, output_column_names: [dict({output_column_names.response: response}, **batch[0])]
+    """Default response parsing function for batch_size=1 - Simply assigns the response to the response column"""
 
     DEFAULT_OUTPUT_COLUMN_PREFIX = "output"
     """Default prefix to add to output columns - should be overriden for personalized output"""
@@ -94,9 +84,8 @@ class DataFrameParallelizer:
         error_handling: ErrorHandling = ErrorHandling.LOG,
         exceptions_to_catch: Tuple[Exception] = (),
         parallel_workers: int = DEFAULT_PARALLEL_WORKERS,
-        batch_support: bool = DEFAULT_BATCH_SUPPORT,
         batch_size: int = DEFAULT_BATCH_SIZE,
-        batch_response_parser: Optional[Callable[[List[Dict], Any, NamedTuple], List[Dict]]] = None,
+        batch_response_parser: Optional[Callable[[List[Dict], Any, NamedTuple], List[Dict]]] = DEFAULT_RESPONSE_PARSER,
         output_column_prefix: AnyStr = DEFAULT_OUTPUT_COLUMN_PREFIX,
         verbose: bool = DEFAULT_VERBOSE,
     ):
@@ -106,11 +95,8 @@ class DataFrameParallelizer:
         if error_handling == ErrorHandling.LOG and not exceptions_to_catch:
             raise ValueError("Please set at least one exception in exceptions_to_catch")
         self.parallel_workers = parallel_workers
-        self.batch_support = batch_support
         self.batch_size = batch_size
         self.batch_response_parser = batch_response_parser
-        if batch_support and not batch_response_parser:
-            raise ValueError("Please provide a valid batch_response_parser function")
         self.output_column_prefix = output_column_prefix
         self.verbose = verbose
         self._output_column_names = None  # Will be set at runtime by the run method
@@ -126,62 +112,41 @@ class DataFrameParallelizer:
         )
 
     def _apply_function_and_parse_response(
-        self, row: Dict = None, batch: List[Dict] = None, **function_kwargs,
+        self, batch: List[Dict] = None, **function_kwargs,
     ) -> Union[Dict, List[Dict]]:  # sourcery skip: or-if-exp-identity
-        """Wrap a row-by-row or batch function with error logging and response parsing
-
+        """Wrap a batch function with error logging and response parsing
         It applies `self.function` and:
-        - If batch, parse the function response to extract results and errors using `self.batch_response_parser`
-        - handles errors from the function with two methods:
+        - Parse the function response to extract results and errors using `self.batch_response_parser`
+        - Handles errors from the function with two methods:
             * (default) log the error message as a warning and return the row with error keys
             * fail if there is an error (if `self.error_handling == ErrorHandling.FAIL`)
-
         """
-        if row and batch:
-            raise (ValueError("Please use either row or batch as arguments, but not both"))
-        output = deepcopy(row) if row else deepcopy(batch)
+        output = deepcopy(batch)
         for output_column in self._output_column_names:
-            if row:
-                output[output_column] = ""
-            else:
                 for output_row in output:
-                    output_row[output_column] = ""
+                    if output_column not in output_row:
+                        output_row[output_column] = ""
         try:
             response = (
-                self.function(row=row, **function_kwargs) if row else self.function(batch=batch, **function_kwargs)
+                self.function(batch=batch, **function_kwargs)
             )
-            if row:
-                output[self._output_column_names.response] = response
-            else:
-                output = self.batch_response_parser(
-                    batch=batch, response=response, output_column_names=self._output_column_names
-                )
-                errors = [
-                    row[self._output_column_names.error_message]
-                    for row in output
-                    if row[self._output_column_names.error_message]
-                ]
-                if errors:
-                    raise BatchError(str(errors))
+            output = self.batch_response_parser(
+                batch=batch, response=response, output_column_names=self._output_column_names
+            )
         except self.exceptions_to_catch + (BatchError,) as error:
             if self.error_handling == ErrorHandling.FAIL:
                 raise error
             logging.warning(
-                f"Function {self.function.__name__} failed on: {row if row else batch} because of error: {error}"
+                f"Function {self.function.__name__} failed on: {batch} because of error: {error}"
             )
             error_type = str(type(error).__qualname__)
             module = inspect.getmodule(error)
             if module:
                 error_type = f"{module.__name__}.{error_type}"
-            if row:
-                output[self._output_column_names.error_message] = str(error)
-                output[self._output_column_names.error_type] = error_type
-                output[self._output_column_names.error_raw] = str(error.args)
-            else:
-                for output_row in output:
-                    output_row[self._output_column_names.error_message] = str(error)
-                    output_row[self._output_column_names.error_type] = error_type
-                    output_row[self._output_column_names.error_raw] = str(error.args)
+            for output_row in output:
+                output_row[self._output_column_names.error_message] = str(error)
+                output_row[self._output_column_names.error_type] = error_type
+                output_row[self._output_column_names.error_raw] = str(error.args)
         return output
 
     def _convert_results_to_df(self, df: pd.DataFrame, results: List[Dict]) -> pd.DataFrame:
@@ -205,59 +170,44 @@ class DataFrameParallelizer:
 
     def run(self, df: pd.DataFrame, **function_kwargs,) -> pd.DataFrame:
         """Apply a function to a pandas.DataFrame with parallelization, error logging and progress tracking
-
-        The DataFrame is iterated on and fed to the function as dictionaries, row-by-row or by batches of rows.
+        The DataFrame is iterated on and fed to the function as dictionaries, by batches of rows.
         This process is accelerated by the use of concurrent threads and is tracked with a progress bar.
         Errors are catched if they match the `self.exceptions_to_catch` attribute and automatically logged.
         Once the whole DataFrame has been iterated on, results and errors are added as additional columns.
-
         Args:
             df: Input dataframe on which the function will be applied
             **function_kwargs: Arbitrary keyword arguments passed to the `function`
-
         Returns:
             Input dataframe with additional columns:
             - response from the `function`
             - error message if any
             - error type if any
-
         """
         # First, we create a generator expression to yield each row of the input dataframe.
         # Each row will be represented as a dictionary like {"column_name_1": "foo", "column_name_2": 42}
         df_row_generator = (index_series_pair[1].to_dict() for index_series_pair in df.iterrows())
+        # We then chunk the generator into lists of rows of len batch_size
+        df_row_batch_generator = chunked(df_row_generator, self.batch_size)
         df_num_rows = len(df.index)
-        start = perf_counter()
-        if self.batch_support:
-            logging.info(
+        len_generator = math.ceil(df_num_rows / self.batch_size)
+        logging.info(
                 f"Applying function {self.function.__name__} in parallel to {df_num_rows} row(s)"
                 + f" using batch size of {self.batch_size}..."
             )
-            df_row_batch_generator = chunked(df_row_generator, self.batch_size)
-            len_generator = math.ceil(df_num_rows / self.batch_size)
-        else:
-            logging.info(f"Applying function {self.function.__name__} in parallel to {df_num_rows} row(s)...")
-            len_generator = df_num_rows
+        start = perf_counter()
         self._output_column_names = self._get_unique_output_column_names(existing_names=df.columns)
         pool_kwargs = function_kwargs.copy()
-        for kwarg in ["function", "row", "batch"]:  # Reserved pool keyword arguments
+        for kwarg in ["function", "batch"]:  # Reserved pool keyword arguments
             pool_kwargs.pop(kwarg, None)
-        if not self.batch_support and "batch_response_parser" in pool_kwargs:
-            pool_kwargs.pop("batch_response_parser", None)
         results = []
         with ThreadPoolExecutor(max_workers=self.parallel_workers) as pool:
-            if self.batch_support:
-                futures = [
-                    pool.submit(self._apply_function_and_parse_response, batch=batch, **pool_kwargs)
-                    for batch in df_row_batch_generator
-                ]
-            else:
-                futures = [
-                    pool.submit(self._apply_function_and_parse_response, row=row, **pool_kwargs)
-                    for row in df_row_generator
-                ]
+            futures = [
+                pool.submit(self._apply_function_and_parse_response, batch=batch, **pool_kwargs)
+                for batch in df_row_batch_generator
+            ]
             for future in tqdm_auto(as_completed(futures), total=len_generator, miniters=1, mininterval=1.0):
                 results.append(future.result())
-        results = flatten(results) if self.batch_support else results
+        results = flatten(results)
         output_df = self._convert_results_to_df(df, results)
         num_error = sum(output_df[self._output_column_names.response] == "")
         num_success = len(df.index) - num_error

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -159,6 +159,9 @@ class DataFrameParallelizer:
             * fail if there is an error (if `self.error_handling == ErrorHandling.FAIL`)
         """
         output = deepcopy(batch)
+        for output_column in self._output_column_names:
+            for output_row in output:
+                output_row[output_column] = ""
         try:
             if self.batch_support is False:
                 # In the row-by-row case, there is only one element in the list as batch_size=1

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -142,7 +142,7 @@ class DataFrameParallelizer:
                 "Please set at least one exception in exceptions_to_catch")
         self.parallel_workers = parallel_workers
         self.batch_support = batch_support
-        if batch_support is False:
+        if not batch_support:
             # Overwrite necessary args for row-by-row iteration
             batch_size = 1
             batch_response_parser = _parse_batch_response_default

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -5,26 +5,26 @@ import logging
 import inspect
 import math
 
-from typing import Callable
-from typing import AnyStr
-from typing import Any
-from typing import List
-from typing import Tuple
-from typing import NamedTuple
-from typing import Dict
-from typing import Union
-from typing import Optional
+from collections import namedtuple
+from collections import OrderedDict
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
-from time import perf_counter
-from collections import namedtuple
-from collections import OrderedDict
 from enum import Enum
+from time import perf_counter
+from typing import Any
+from typing import AnyStr
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import NamedTuple
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
-import pandas as pd
 from more_itertools import chunked
 from more_itertools import flatten
+import pandas as pd
 from tqdm.auto import tqdm as tqdm_auto
 
 from dkulib.io_utils.plugin_io_utils import generate_unique

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -139,6 +139,8 @@ class DataFrameParallelizer:
         self.batch_support = batch_support
         if batch_support is False:
             batch_size = 1
+            assert batch_response_parser == _parse_batch_response_default, "The default batch response parser " \
+                                                                + "should be used when batch_support is False."
         self.batch_size = batch_size
         self.batch_response_parser = batch_response_parser
         self.output_column_prefix = output_column_prefix


### PR DESCRIPTION
Solves [ch65583](https://app.clubhouse.io/dataiku/story/65583/parallelizer-hold-data-in-lists-for-both-batch-and-row-by-row-case)

Main points:
- Sets default batch_size=1
- In case of single row api callable functions users still need to use batch as a keyword argument and extract the row with batch[0]
- Removes row-related keyword arguments & logic
- Adds default response parser for batch_size=1

Q's / Improvements:
- Do we need the deepcopy operation in _apply_function_and_parse_response or can we just operate on the batch directly in the exception case?

