### PR TITLE
Use relative import

### DIFF
--- a/dkulib/nlp/language_detector.py
+++ b/dkulib/nlp/language_detector.py
@@ -16,7 +16,7 @@ from .language_dict import (
     LANGUAGE_REMAPPING_PYCLD3_LANGID,
 )
 
-from dkulib.io_utils.plugin_io_utils import generate_unique, truncate_text_list
+from ..io_utils.plugin_io_utils import generate_unique, truncate_text_list
 
 
 class LanguageDetector:

--- a/dkulib/nlp/spacy_tokenizer.py
+++ b/dkulib/nlp/spacy_tokenizer.py
@@ -19,7 +19,7 @@ from emoji import UNICODE_EMOJI
 from fastcore.utils import store_attr
 
 from .language_dict import SUPPORTED_LANGUAGES_SPACY, SPACY_LANGUAGE_MODELS
-from dkulib.io_utils.plugin_io_utils import generate_unique, truncate_text_list
+from ..io_utils.plugin_io_utils import generate_unique, truncate_text_list
 
 
 # Setting custom spaCy token extensions to allow for easier filtering in downstream tasks

--- a/dkulib/nlp/symspell_checker.py
+++ b/dkulib/nlp/symspell_checker.py
@@ -16,7 +16,7 @@ from spacy.vocab import Vocab
 from symspellpy.symspellpy import SymSpell, Verbosity
 from fastcore.utils import store_attr
 
-from dkulib.io_utils.plugin_io_utils import unique_list, generate_unique, truncate_text_list, clean_empty_list, time_logging
+from ..io_utils.plugin_io_utils import unique_list, generate_unique, truncate_text_list, clean_empty_list, time_logging
 from .spacy_tokenizer import MultilingualTokenizer
 from .language_dict import SUPPORTED_LANGUAGES_SYMSPELL
 

--- a/dkulib/nlp/text_cleaner.py
+++ b/dkulib/nlp/text_cleaner.py
@@ -15,7 +15,7 @@ from spacy.tokens import Doc, Token
 from fastcore.utils import store_attr
 
 from .spacy_tokenizer import MultilingualTokenizer
-from dkulib.io_utils.plugin_io_utils import generate_unique
+from ..io_utils.plugin_io_utils import generate_unique
 
 
 WHITESPACE_REGEX = re.compile(r" +")

--- a/dkulib/parallelizer/parallelizer.py
+++ b/dkulib/parallelizer/parallelizer.py
@@ -26,7 +26,7 @@ from more_itertools import flatten
 import pandas as pd
 from tqdm.auto import tqdm as tqdm_auto
 
-from dkulib.io_utils.plugin_io_utils import generate_unique
+from ..io_utils.plugin_io_utils import generate_unique
 
 
 class ErrorHandling(Enum):


### PR DESCRIPTION
Use a relative import instead of an absolute import to make usage as a submodule easier

Else the imports need to be changed in the submodule, which isn't a neat solution, as the submodule should be left untouched


I only changed it for parallelizer for now, but if you agree we can change it for all files (except perhaps tests)