### PR TITLE
Update spacy to v3

### DIFF
--- a/core/nlp/__init__.py
+++ b/core/nlp/__init__.py
@@ -1,9 +1,9 @@
 ########################################################
-# ------------- nlp: 0.1.0 ----------------
+# ------------- nlp: 0.2.0 ----------------
 
 # For more information, see https://github.com/dataiku/dss-plugin-dkulib/tree/main/core/nlp
-# Library version: 0.1.0
-# Last update: 2021-01-11
+# Library version: 0.2.0
+# Last update: 2021-08-23
 # Author: Dataiku (Alex Combessie)
 #########################################################
 

--- a/core/nlp/language_detector.py
+++ b/core/nlp/language_detector.py
@@ -10,7 +10,7 @@ import cld3
 from langid.langid import LanguageIdentifier, model
 from fastcore.utils import store_attr
 
-from .language_dict import (
+from .language_support import (
     SUPPORTED_LANGUAGES_PYCLD3,
     SUPPORTED_LANGUAGES_PYCLD3_NOT_LANGID,
     LANGUAGE_REMAPPING_PYCLD3_LANGID,

--- a/core/nlp/language_support.py
+++ b/core/nlp/language_support.py
@@ -118,7 +118,6 @@ SUPPORTED_LANGUAGES_PYCLD3 = {
     "zu": "Zulu",
 }
 """dict: Languages supported by pycld3
-
 Dictionary with ISO 639-1 language code (key) and language name (value)
 """
 
@@ -187,7 +186,6 @@ SUPPORTED_LANGUAGES_SYMSPELL = {
     "zh": "Chinese (simplified)",
 }
 """dict: SymSpell dictionaries included in this plugin
-
 Dictionary with ISO 639-1 language code (key) and language name (value)
 """
 
@@ -218,6 +216,7 @@ SUPPORTED_LANGUAGES_SPACY = {
     "id": "Indonesian",
     "is": "Icelandic",
     "it": "Italian",
+    "ja": "Japanese",
     "kn": "Kannada",
     "lb": "Luxembourgish",
     "lt": "Lithuanian",
@@ -251,22 +250,67 @@ SUPPORTED_LANGUAGES_SPACY = {
     "yo": "Yoruba",
     "zh": "Chinese (simplified)",
 }
-"""dict: Languages supported by spaCy: https://spacy.io/usage/models#languages
 
+"""dict: Languages supported by spaCy: https://spacy.io/usage/models#languages
 Dictionary with ISO 639-1 language code (key) and language name (value)
-Japanese and Korean were excluded for now because of system installation issues
+Korean is excluded for now because of system installation issues
 """
 
 SPACY_LANGUAGE_MODELS = {
+    "de": "de_core_news_sm",  # OntoNotes
     "en": "en_core_web_sm",  # OntoNotes
     "es": "es_core_news_sm",  # Wikipedia
-    "zh": "zh_core_web_sm",  # OntoNotes
-    "xx": "xx_ent_wiki_sm",  # Wikipedia
-    "pl": "nb_core_news_sm",  # NorNE
     "fr": "fr_core_news_sm",  # Wikipedia
-    "de": "de_core_news_sm",  # OntoNotes
+    "nb": "nb_core_news_sm",  # NorNE
+    "pl": "pl_core_news_sm",  # NKJP
+    "ru": "ru_core_news_sm",  # Nerus
+    "zh": "zh_core_web_sm",  # OntoNotes
 }
-"""dict: Mapping between ISO 639-1 language code and spaCy model identifiers
 
+"""dict: Mapping between ISO 639-1 language code and spaCy model identifiers
 Models with Creative Commons licenses are not included because this plugin is licensed under Apache-2
+"""
+
+SPACY_LANGUAGE_MODELS_LEMMATIZATION = ["de", "en", "es", "fr", "nb", "pl", "ru"]
+"""list: Languages that have a SpaCy pre-trained model with a Lemmatizer component.
+When using a pre-trained pipeline to lemmatize, you need to have in your SpaCy Language pipeline:
+-either SpaCy 'morphologizer' + 'lemmatizer'
+-or SpaCy 'tagger' + 'attribute ruler' + 'lemmatizer'
+depending on the pre-trained pipeline built-in components"""
+
+SPACY_LANGUAGE_MODELS_MORPHOLOGIZER = ["de", "es", "fr", "nb", "pl", "ru"]
+"""list: Languages that have a SpaCy pre-trained model with a Morphologizer component."""
+
+SPACY_LANGUAGE_LOOKUP = [
+    "ca",
+    "cs",
+    "da",
+    "de",
+    "en",
+    "es",
+    "fr",
+    "hr",
+    "hu",
+    "id",
+    "it",
+    "lb",
+    "lt",
+    "mk",
+    "nb",
+    "nl",
+    "pt",
+    "ro",
+    "sr",
+    "sv",
+    "tl",
+    "tr",
+    "ur",
+]
+"""list: Languages that have available SpaCy lookup tables for lemmatization. 
+The lookup tables are available at https://github.com/explosion/spacy-lookups-data/tree/master/spacy_lookups_data/data
+"""
+
+SPACY_LANGUAGE_RULES = ["bn", "el", "fa"]
+"""list: Languages that have available SpaCy rule tables for lemmatization
+The rule tables are available at https://github.com/explosion/spacy-lookups-data/tree/master/spacy_lookups_data/data
 """

--- a/core/nlp/requirements.txt
+++ b/core/nlp/requirements.txt
@@ -8,6 +8,6 @@ pymorphy2-dicts-uk==2.4.1.1.1460299261
 pymorphy2==0.9.1
 pyvi==0.1
 regex==2020.11.13
-spacy[lookups,ja,th]~=3.0
+spacy[lookups,ja,th]==3.0.7
 symspellpy==6.7.0
 tqdm==4.50.2

--- a/core/nlp/requirements.txt
+++ b/core/nlp/requirements.txt
@@ -1,5 +1,5 @@
-emoji==0.6.0
-fastcore==1.3.1
+emoji==1.2.0
+fastcore==1.3.19
 jieba==0.42.1
 langid==1.1.6
 pycld3==0.20
@@ -7,8 +7,7 @@ pymorphy2-dicts-ru==2.4.417127.4579844
 pymorphy2-dicts-uk==2.4.1.1.1460299261
 pymorphy2==0.9.1
 pyvi==0.1
-regex==2020.10.28
-spacy[lookups,th]==2.3.5
-spacymoji==2.0.0
+regex==2020.11.13
+spacy[lookups,ja,th]~=3.0
 symspellpy==6.7.0
 tqdm==4.50.2

--- a/core/nlp/spacy_tokenizer.py
+++ b/core/nlp/spacy_tokenizer.py
@@ -122,7 +122,7 @@ class MultilingualTokenizer:
 
     DEFAULT_BATCH_SIZE = 1000
     MAX_NUM_CHARACTERS = 10 ** 7
-    DEFAULT_NUM_PROCESS = 1
+    DEFAULT_NUM_PROCESS = 2
     DEFAULT_FILTER_TOKEN_ATTRIBUTES = {
         "is_space": "Whitespace",
         "is_punct": "Punctuation",

--- a/core/nlp/spacy_tokenizer.py
+++ b/core/nlp/spacy_tokenizer.py
@@ -269,6 +269,7 @@ class MultilingualTokenizer:
                 nlp = spacy.load(SPACY_LANGUAGE_MODELS[language])
             # Since v3, spaCy uses char tokenization by default for Chinese, not jieba anymore
             # See https://github.com/explosion/spaCy/blob/e1f88de729f113f068958c824cf01026363bb110/spacy/lang/zh/__init__.py
+            # If a model is selected, jieba is not needed - see https://github.com/explosion/spaCy/discussions/8577#discussioncomment-955726
             elif language == "zh":
                 nlp = Chinese.from_config({"nlp": {"tokenizer": {"segmenter": "jieba"}}})
             else:

--- a/core/nlp/spacy_tokenizer.py
+++ b/core/nlp/spacy_tokenizer.py
@@ -4,7 +4,7 @@
 import regex as re
 import os
 import logging
-from typing import List, AnyStr
+from typing import List, AnyStr, Union, Optional
 from time import perf_counter
 from tempfile import mkdtemp
 
@@ -14,19 +14,32 @@ import spacy
 from spacy.language import Language
 from spacy.tokens import Doc, Token
 from spacy.vocab import Vocab
-from spacymoji import Emoji
+from spacy.lang.zh import Chinese
 from emoji import UNICODE_EMOJI
 from fastcore.utils import store_attr
 
-from .language_dict import SUPPORTED_LANGUAGES_SPACY, SPACY_LANGUAGE_MODELS
+from .language_support import (
+    SUPPORTED_LANGUAGES_SPACY,
+    SPACY_LANGUAGE_MODELS,
+    SPACY_LANGUAGE_LOOKUP,
+    SPACY_LANGUAGE_RULES,
+    SPACY_LANGUAGE_MODELS_LEMMATIZATION,
+    SPACY_LANGUAGE_MODELS_MORPHOLOGIZER,
+)
 from ..io_utils.plugin_io_utils import generate_unique, truncate_text_list
 
 
 # Setting custom spaCy token extensions to allow for easier filtering in downstream tasks
 Token.set_extension("is_hashtag", getter=lambda token: token.text[0] == "#", force=True)
 Token.set_extension("is_username", getter=lambda token: token.text[0] == "@", force=True)
-Token.set_extension("is_emoji", getter=lambda token: any(c in UNICODE_EMOJI for c in token.text), force=True)
-SYMBOL_CHARS_REGEX = re.compile(r"(\p{M}|\p{S})+")  # matches unicode categories M (marks) and S (symbols)
+Token.set_extension(
+    "is_emoji",
+    getter=lambda token: any(c in UNICODE_EMOJI for c in token.text),
+    force=True,
+)
+SYMBOL_CHARS_REGEX = re.compile(
+    r"(\p{M}|\p{S})+"
+)  # matches unicode categories M (marks) and S (symbols)
 Token.set_extension(
     "is_symbol",
     getter=lambda token: not token.is_punct
@@ -35,7 +48,9 @@ Token.set_extension(
     and not re.sub(SYMBOL_CHARS_REGEX, "", token.text).strip(),
     force=True,
 )
-DATETIME_REGEX = re.compile(r"(:|-|\.|\/|am|pm|hrs|hr|h|minutes|mins|min|sec|s|ms|ns|y)+", flags=re.IGNORECASE)
+DATETIME_REGEX = re.compile(
+    r"(:|-|\.|\/|am|pm|hrs|hr|h|minutes|mins|min|sec|s|ms|ns|y)+", flags=re.IGNORECASE
+)
 Token.set_extension(
     "is_datetime",
     getter=lambda token: not token.like_num  # avoid conflict with existing token attribute
@@ -55,7 +70,12 @@ Token.set_extension(
     getter=lambda token: not token.like_num  # avoid conflict with existing token attribute
     and not getattr(token._, "is_datetime", False)
     and token.text[:1].isdigit()
-    and any([re.sub(NUMERIC_SEPARATOR_REGEX, "", token.lower_).replace(unit, "").isdigit() for unit in ALL_UNITS]),
+    and any(
+        [
+            re.sub(NUMERIC_SEPARATOR_REGEX, "", token.lower_).replace(unit, "").isdigit()
+            for unit in ALL_UNITS
+        ]
+    ),
     force=True,
 )
 INVISIBLE_CHARS_REGEX = re.compile(
@@ -63,7 +83,9 @@ INVISIBLE_CHARS_REGEX = re.compile(
 )  # matches unicode categories C (control chars), Z (separators) and M (marks)
 Token.set_extension(
     "is_space",
-    getter=lambda token: not getattr(token._, "is_symbol", False)  # avoid conflict with existing token attribute
+    getter=lambda token: not getattr(
+        token._, "is_symbol", False
+    )  # avoid conflict with existing token attribute
     and (
         not "".join(c for c in token.text.strip() if c.isprintable())
         or not re.sub(INVISIBLE_CHARS_REGEX, "", token.text.strip())
@@ -80,7 +102,6 @@ class TokenizationError(RuntimeError):
 
 class MultilingualTokenizer:
     """Wrapper class to handle tokenization with spaCy for multiple languages
-
     Attributes:
         stopwords_folder_path: Path to a folder with stopword text files (one line per stopword)
             Files should be named "{language_code}.txt" with the code in ISO 639-1 format
@@ -88,13 +109,20 @@ class MultilingualTokenizer:
             Slower but adds additional tagging capabilities to the pipeline.
         hashtags_as_token (bool): Treat hashtags as one token instead of two
         batch_size (int): Number of documents to process in spaCy pipelines
+        max_num_characters (int): Maximum number of characters in a single text
+        add_pipe_components (list): List of spaCy pipeline components to add, for instance "sentencizer"
+        enable_pipe_components (list, optional): List of spaCy pipeline components to enable
+        disable_pipe_components (list, optional): List of spaCy pipeline components to disable.
+        config (dict): Dictionary for SpaCy component(key) and its associated SpaCy.Language.config dictionary (value)
+            This config dictionary contains metadatas about the component.
+            If empty, uses SpaCy default config, describing the default values of the factory arguments
         spacy_nlp_dict (dict): Dictionary holding spaCy Language instances (value) by language code (key)
         tokenized_column (str): Name of the dataframe column storing tokenized documents
-
     """
 
     DEFAULT_BATCH_SIZE = 1000
-    DEFAULT_NUM_PROCESS = 2
+    MAX_NUM_CHARACTERS = 10 ** 7
+    DEFAULT_NUM_PROCESS = 1
     DEFAULT_FILTER_TOKEN_ATTRIBUTES = {
         "is_space": "Whitespace",
         "is_punct": "Punctuation",
@@ -111,57 +139,160 @@ class MultilingualTokenizer:
         "is_emoji": "Emoji",
     }
     """dict: Available native and custom spaCy token attributes for filtering
-
     Key: name of the token attribute defined on spacy Token objects
     Value: label to designate the token attribute in the user interface
     """
 
     def __init__(
         self,
-        stopwords_folder_path: AnyStr = None,
+        stopwords_folder_path: Optional[AnyStr] = None,
         use_models: bool = False,
         hashtags_as_token: bool = True,
         batch_size: int = DEFAULT_BATCH_SIZE,
+        max_num_characters: int = MAX_NUM_CHARACTERS,
+        add_pipe_components: List[str] = [],
+        enable_pipe_components: Optional[Union[List[str], str]] = None,
+        disable_pipe_components: Optional[Union[List[str], str]] = None,
+        config: dict = {},
     ):
         """Initialization method for the MultilingualTokenizer class, with optional arguments
-
         Args:
-            stopwords_folder_path (str, optional): Path to a folder with stopword text files (one line per stopword)
-                Files should be named "{language_code}.txt" with the code in ISO 639-1 format
-            use_models (bool, optional): If True (default), loads spaCy models, which is slower but allows to retrieve
-                Part-of-Speech and Entities tags for downstream tasks
-            hashtags_as_token (bool, optional): Treat hashtags as one token instead of two
-                Default is True, which overrides the spaCy default behavior
-            batch_size (int, optional): Number of documents to process in spaCy pipelines
-                Default is set by the DEFAULT_BATCH_SIZE class constant
-
+            stopwords_folder_path (str, optional): Path to a folder with stopword text files (one line per stopword).
+                Files should be named "{language_code}.txt" with the code in ISO 639-1 format.
+            use_models (bool): If True, loads spaCy models, which is slower but allows to retrieve
+                Part-of-Speech and Entities tags for downstream tasks. Default is False.
+            hashtags_as_token (bool): Treat hashtags as one token instead of two.
+                Default is True, which overrides the spaCy default behavior.
+            batch_size (int): Number of documents to process in spaCy pipelines.
+                Default is set by the DEFAULT_BATCH_SIZE class constant.
+            max_num_characters (int): Maximum number of characters in a single text.
+                Default is 10 million, higher than spaCy more conservative default at 1 million.
+            add_pipe_components (list): List of spaCy pipeline components to add, for instance "sentencizer".
+                If use_models is False, only the tokenizer component is present so other components must be added explicitly.
+                If use_models is True, several pipeline components are automatically added.
+                Please refer to the spaCy documentation to know which components are available for each model.
+            enable_pipe_components (list, optional): List of spaCy pipeline components to enable.
+                To enable components, they must be added first, either by activating use_models
+                or by adding them explicitly in add_pipe_components.
+            disable_pipe_components (list, optional): List of spaCy pipeline components to disable.
+                To disable components, they must be added first, either by activating use_models
+                or by adding them explicitly in add_pipe_components.
+                Please use either enable_pipe_components or disable_pipe_components, as both cannot be used at the same time.
+            config (dict): Dictionary for SpaCy component(key) and its associated SpaCy.Language.config dictionary (value)
+                This config dictionary contains metadatas about the component.
+                If empty, uses SpaCy default config, describing the default values of the factory arguments
         """
         store_attr()
         self.spacy_nlp_dict = {}
         self.tokenized_column = None  # may be changed by tokenize_df
+        self._restore_pipe_components = {}
+        """spacy.language.DisabledPipes object initialized in create_spacy_tokenizer()
+        Contains the components of each SpaCy.Language object that have been disabled by spacy.Languages.select_pipes() method.
+        Those components can be re-added to each SpaCy.Language at their initial place in the pipeline, by calling restore_pipe_components[language].restore()
+        
+        """
+        if self.enable_pipe_components and self.disable_pipe_components:
+            raise ValueError(
+                "Only one of enable_pipe_components and disable_pipe_components can be specified at once."
+            )
+
+    def _set_use_models(self, languages: List[AnyStr]) -> bool:
+        """Set self.use_models attribute to True in case the text should be lemmatize with a SpaCy pre-trained model.
+        (e.g no lookups available for all languages in spacy-lookups-data)
+        This method should be called before creating your SpaCy Language object through create_spacy_tokenizer() method"""
+        if "pl" in languages or "ru" in languages:
+            self.use_models = True
+        else:
+            self.use_models = False
+
+    @staticmethod
+    def _get_error_message_lemmatization(language: AnyStr) -> AnyStr:
+        """Return the error message to display when the lemmatization cannot be applied"""
+        if language in SPACY_LANGUAGE_MODELS_LEMMATIZATION:
+            # 'Russian','Polish' without a pretrained model
+            return f"The language '{language}' is not available for Lemmatization without loading a pre-trained model. Set use_models to True to lemmatize in '{language}'"
+        else:
+            # Any unsupported language
+            return f"The language '{language}' is not available for Lemmatization. Uncheck the lemmatization option and re-run the recipe."
+
+    @staticmethod
+    def _get_components_to_activate_lemmatization(language: AnyStr) -> List[AnyStr]:
+        """Return the list of  SpaCy components to add to SpaCy Language to lemmatize"""
+        if language in SPACY_LANGUAGE_MODELS_MORPHOLOGIZER:
+            return ["tok2vec", "morphologizer", "lemmatizer"]
+        else:
+            return ["tok2vec", "tagger", "attribute_ruler", "lemmatizer"]
+
+    def _activate_components_to_lemmatize(self, language: AnyStr) -> None:
+        """Set the components of SpaCy Language to lemmatize text:
+        - If SpaCy Language is load as a pre-trained model: enable tok2vec, morphologizer and lemmatizer
+        - Else: Add a Lemmatizer in the available mode 'rule' or 'lookup'
+        (cf https://github.com/explosion/spacy-lookups-data/tree/master/spacy_lookups_data/data )
+        """
+        if self.use_models and language in SPACY_LANGUAGE_MODELS_LEMMATIZATION:
+            # When using a pre-trained model
+            components_to_activate = self._get_components_to_activate_lemmatization(language)
+            if language in self._restore_pipe_components:
+                self._restore_pipe_components[language].restore()
+            self._restore_pipe_components[language] = self.spacy_nlp_dict[language].select_pipes(
+                enable=components_to_activate
+            )
+        elif language in SPACY_LANGUAGE_LOOKUP:
+            # When using spacy lookups
+            self.spacy_nlp_dict[language].add_pipe("lemmatizer", config={"mode": "lookup"})
+            self.spacy_nlp_dict[language].initialize()
+        elif language in SPACY_LANGUAGE_RULES:
+            # When using spacy rules (e.g in case there is no spacy lookup available)
+            self.spacy_nlp_dict[language].add_pipe("lemmatizer", config={"mode": "rule"})
+            self.spacy_nlp_dict[language].initialize()
+        else:
+            # unsupported cases
+            raise ValueError(self._get_error_message_lemmatization(language))
 
     def _create_spacy_tokenizer(self, language: AnyStr) -> Language:
         """Private method to create a custom spaCy tokenizer for a given language
-
         Args:
             language: Language code in ISO 639-1 format, cf. https://spacy.io/usage/models#languages
-
         Returns:
             spaCy Language instance with the tokenizer
-
         Raises:
             TokenizationError: If something went wrong with the tokenizer creation
-
         """
         start = perf_counter()
         logging.info(f"Loading tokenizer for language '{language}'...")
         try:
-            if language == "th":  # PyThaiNLP requires a "data directory" even if nothing needs to be downloaded
+            if (
+                language == "th"
+            ):  # PyThaiNLP requires a "data directory" even if nothing needs to be downloaded
                 os.environ["PYTHAINLP_DATA_DIR"] = mkdtemp()  # dummy temp directory
             if language in SPACY_LANGUAGE_MODELS and self.use_models:
                 nlp = spacy.load(SPACY_LANGUAGE_MODELS[language])
+            # Since v3, spaCy uses char tokenization by default for Chinese, not jieba anymore
+            # See https://github.com/explosion/spaCy/blob/e1f88de729f113f068958c824cf01026363bb110/spacy/lang/zh/__init__.py
+            elif language == "zh":
+                nlp = Chinese.from_config({"nlp": {"tokenizer": {"segmenter": "jieba"}}})
             else:
-                nlp = spacy.blank(language)  # spaCy language without models (https://spacy.io/usage/models)
+                nlp = spacy.blank(
+                    language
+                )  # spaCy language without models (https://spacy.io/usage/models)
+            nlp.max_length = self.max_num_characters
+            for component in self.add_pipe_components:
+                nlp.add_pipe(
+                    component,
+                    config=self.config[component] if component in self.config else {},
+                )
+            # if self.config is None, uses SpaCy default config, describing the default values of the factory arguments
+            if not self.use_models:
+                nlp.initialize()
+            if self.enable_pipe_components:
+                self._restore_pipe_components[language] = nlp.select_pipes(
+                    enable=self.enable_pipe_components
+                )
+            if self.disable_pipe_components:
+                self._restore_pipe_components[language] = nlp.select_pipes(
+                    disable=self.disable_pipe_components
+                )
+
         except (ValueError, OSError) as e:
             raise TokenizationError(
                 f"SpaCy tokenization not available for language '{language}' because of error: '{e}'"
@@ -176,23 +307,18 @@ class MultilingualTokenizer:
                 nlp.tokenizer.prefix_search = spacy.util.compile_prefix_regex(_prefixes).search
         if self.stopwords_folder_path and language in SUPPORTED_LANGUAGES_SPACY:
             self._customize_stopwords(nlp, language)
-        try:
-            nlp.add_pipe(Emoji(nlp), first=True)
-        except (AttributeError, ValueError) as e:
-            logging.warning(f"Spacymoji not available for language '{language}' because of error: '{e}'")
-        logging.info(f"Loading tokenizer for language '{language}': done in {perf_counter() - start:.2f} seconds")
+        logging.info(
+            f"Loading tokenizer for language '{language}': done in {perf_counter() - start:.2f} seconds"
+        )
         return nlp
 
     def _customize_stopwords(self, nlp: Language, language: AnyStr) -> None:
         """Private method to customize stopwords for a given spaCy language
-
         Args:
             nlp: Instanciated spaCy language
             language: Language code in ISO 639-1 format, cf. https://spacy.io/usage/models#languages
-
         Raises:
             TokenizationError: If something went wrong with the stopword customization
-
         """
         try:
             stopwords_file_path = os.path.join(self.stopwords_folder_path, f"{language}.txt")
@@ -209,24 +335,21 @@ class MultilingualTokenizer:
                     nlp.vocab[word.upper()].is_stop = False
             nlp.Defaults.stop_words = custom_stopwords
         except (ValueError, OSError) as e:
-            raise TokenizationError(f"Stopword file for language '{language}' not available because of error: '{e}'")
+            raise TokenizationError(
+                f"Stopword file for language '{language}' not available because of error: '{e}'"
+            )
 
-    def _add_spacy_tokenizer(self, language: AnyStr) -> bool:
+    def add_spacy_tokenizer(self, language: AnyStr) -> bool:
         """Private method to add a spaCy tokenizer for a given language to the `spacy_nlp_dict` attribute
-
         This method only adds the tokenizer if the language code is valid and recognized among
         the list of supported languages (`SUPPORTED_LANGUAGES_SPACY` constant),
         else it will raise a TokenizationError exception.
-
         Args:
             language: Language code in ISO 639-1 format, cf. https://spacy.io/usage/models#languages
-
         Returns:
             True if the tokenizer was added, else False
-
         Raises:
             TokenizationError: If the language code is missing or not in SUPPORTED_LANGUAGES_SPACY
-
         """
         added_tokenizer = False
         if pd.isnull(language) or language == "":
@@ -236,56 +359,57 @@ class MultilingualTokenizer:
         if language not in self.spacy_nlp_dict:
             self.spacy_nlp_dict[language] = self._create_spacy_tokenizer(language)
             added_tokenizer = True
+
         return added_tokenizer
 
     def tokenize_list(self, text_list: List[AnyStr], language: AnyStr) -> List[Doc]:
         """Public method to tokenize a list of strings for a given language
-
         This method calls `_add_spacy_tokenizer` in case the requested language has not already been added.
         In case of an error in `_add_spacy_tokenizer`, it falls back to the default tokenizer.
-
         Args:
             text_list: List of strings
             language: Language code in ISO 639-1 format, cf. https://spacy.io/usage/models#languages
-
         Returns:
             List of tokenized spaCy documents
-
         """
         start = perf_counter()
         logging.info(f"Tokenizing {len(text_list)} document(s) in language '{language}'...")
         text_list = [str(t) if pd.notnull(t) else "" for t in text_list]
         try:
-            self._add_spacy_tokenizer(language)
+            self.add_spacy_tokenizer(language)
             tokenized = list(
                 self.spacy_nlp_dict[language].pipe(
-                    text_list, batch_size=self.batch_size, n_process=self.DEFAULT_NUM_PROCESS
+                    text_list,
+                    batch_size=self.batch_size,
+                    n_process=self.DEFAULT_NUM_PROCESS,
                 )
             )
             logging.info(
                 f"Tokenizing {len(tokenized)} document(s) in language '{language}': done in {perf_counter() - start:.2f} seconds"
             )
         except TokenizationError as e:
-            raise TokenizationError(f"Tokenization error: {e} for document(s): '{truncate_text_list(text_list)}'")
+            raise TokenizationError(
+                f"Tokenization error: {e} for document(s): '{truncate_text_list(text_list)}'"
+            )
         return tokenized
 
     def tokenize_df(
-        self, df: pd.DataFrame, text_column: AnyStr, language_column: AnyStr = "", language: AnyStr = "language_column"
+        self,
+        df: pd.DataFrame,
+        text_column: AnyStr,
+        language_column: AnyStr = "",
+        language: AnyStr = "language_column",
     ) -> pd.DataFrame:
         """Public method to tokenize a text column in a pandas DataFrame, given language information
-
         This methods adds a new column to the DataFrame, whose name is saved as the `tokenized_column` attribute
-
         Args:
             df: Input pandas DataFrame
             text_column: Name of the column containing text data
             language_column: Name of the column with language codes in ISO 639-1 format
             language: Language code in ISO 639-1 format, cf. https://spacy.io/usage/models#languages
                 if equal to "language_column" this parameter is ignored in favor of language_column
-
         Returns:
             DataFrame with all columns from the input, plus a new column with tokenized spaCy documents
-
         """
         self.tokenized_column = generate_unique("tokenized", df.keys(), text_column)
         # Initialize the tokenized column to empty documents
@@ -302,8 +426,11 @@ class MultilingualTokenizer:
                 text_slice = df.loc[language_indices, text_column]  # slicing input df by language
                 if len(text_slice) != 0:
                     tokenized_list = self.tokenize_list(text_list=text_slice, language=lang)
+
                     df.loc[language_indices, self.tokenized_column] = pd.Series(
-                        tokenized_list, dtype="object", index=text_slice.index,  # keep index (important)
+                        tokenized_list,
+                        dtype="object",
+                        index=text_slice.index,  # keep index (important)
                     )
         else:
             tokenized_list = self.tokenize_list(text_list=df[text_column], language=language)

--- a/core/nlp/symspell_checker.py
+++ b/core/nlp/symspell_checker.py
@@ -18,7 +18,7 @@ from fastcore.utils import store_attr
 
 from ..io_utils.plugin_io_utils import unique_list, generate_unique, truncate_text_list, clean_empty_list, time_logging
 from .spacy_tokenizer import MultilingualTokenizer
-from .language_dict import SUPPORTED_LANGUAGES_SYMSPELL
+from .language_support import SUPPORTED_LANGUAGES_SYMSPELL
 
 # Setting custom spaCy token extensions to store spellchecking information
 Token.set_extension("is_misspelled", default=False, force=True)

--- a/tests/nlp/test_spacy_tokenizer.py
+++ b/tests/nlp/test_spacy_tokenizer.py
@@ -19,6 +19,12 @@ def test_tokenize_df_english():
     tokenized_document = output_df[tokenizer.tokenized_column][0]
     assert len(tokenized_document) == 15
 
+def test_tokenize_df_japanese():
+    input_df = pd.DataFrame({"input_text": ["期一会。 異体同心。 そうです。"]})
+    tokenizer = MultilingualTokenizer()
+    output_df = tokenizer.tokenize_df(df=input_df, text_column="input_text", language="ja")
+    tokenized_document = output_df[tokenizer.tokenized_column][0]
+    assert len(tokenized_document) == 9
 
 def test_tokenize_df_multilingual():
     input_df = pd.DataFrame(
@@ -36,3 +42,38 @@ def test_tokenize_df_multilingual():
     tokenized_documents = output_df[tokenizer.tokenized_column]
     tokenized_documents_length = [len(doc) for doc in tokenized_documents]
     assert tokenized_documents_length == [12, 8, 13]
+
+def test_tokenize_df_long_text():
+    input_df = pd.DataFrame({"input_text": ["Long text"]})
+    tokenizer = MultilingualTokenizer(max_num_characters=1)
+    with pytest.raises(ValueError):
+        tokenizer.tokenize_df(df=input_df, text_column="input_text", language="en")
+
+        
+def test_create_spacy_tokenizer_no_model():
+    input_df = pd.DataFrame({"input_text": ["I hope nothing. I fear nothing. I am free. 💩 😂 #OMG"]})
+    tokenizer = MultilingualTokenizer(add_pipe_components=["sentencizer"],enable_pipe_components=["sentencizer"],use_models=False)
+    nlp = tokenizer._create_spacy_tokenizer("en")
+    assert nlp.pipe_names == ["sentencizer"]
+    
+    
+def test_create_spacy_tokenizer_model():
+    input_df = pd.DataFrame({"input_text": ["I hope nothing. I fear nothing. I am free. 💩 😂 #OMG"]})
+    tokenizer = MultilingualTokenizer(add_pipe_components=["sentencizer"],enable_pipe_components=["tagger","sentencizer"],use_models=True)
+    nlp = tokenizer._create_spacy_tokenizer("en")
+    assert nlp.pipe_names == ["tagger","sentencizer"]    
+    
+def test_activate_components_to_lemmatize_no_model():
+    input_df = pd.DataFrame({"input_text": ["I hope nothing. I fear nothing. I am free. 💩 😂 #OMG"]})
+    tokenizer = MultilingualTokenizer(enable_pipe_components=["sentencizer","tagger"],use_models=False)
+    tokenizer.spacy_nlp_dict["en"] = tokenizer._create_spacy_tokenizer("en")
+    tokenizer._activate_components_to_lemmatize("en")
+    assert tokenizer.spacy_nlp_dict["en"].pipe_names == ["lemmatizer"]
+    
+
+def test_activate_components_to_lemmatize_model():
+    input_df = pd.DataFrame({"input_text": ["I hope nothing. I fear nothing. I am free. 💩 😂 #OMG"]})
+    tokenizer = MultilingualTokenizer(enable_pipe_components=["sentencizer","tagger"],use_models=True)
+    tokenizer.spacy_nlp_dict["en"] = tokenizer._create_spacy_tokenizer("en")
+    tokenizer._activate_components_to_lemmatize("en")
+    assert tokenizer.spacy_nlp_dict["en"].pipe_names == ["tok2vec","tagger","attribute_ruler","lemmatizer"]

--- a/tests/nlp/test_text_cleaner.py
+++ b/tests/nlp/test_text_cleaner.py
@@ -15,7 +15,10 @@ stopwords_folder_path = os.getenv("STOPWORDS_FOLDER_PATH", "path_is_no_good")
 def test_clean_df_english():
     input_df = pd.DataFrame({"input_text": ["Hi, I have two apples costing 3$ 😂    \n and unicode has #snowpersons ☃"]})
     token_filters = {"is_punct", "is_stop", "like_num", "is_symbol", "is_currency", "is_emoji"}
-    text_cleaner = TextCleaner(tokenizer=MultilingualTokenizer(), token_filters=token_filters, lemmatization=True)
+    tokenizer = MultilingualTokenizer()
+    tokenizer.spacy_nlp_dict["en"] = tokenizer._create_spacy_tokenizer("en")
+    tokenizer._activate_components_to_lemmatize("en")
+    text_cleaner = TextCleaner(tokenizer=tokenizer, token_filters=token_filters, lemmatization=True)
     output_df = text_cleaner.clean_df(df=input_df, text_column="input_text", language="en")
     cleaned_text_column = list(text_cleaner.output_column_descriptions.keys())[0]
     cleaned_text = output_df[cleaned_text_column][0]
@@ -35,8 +38,12 @@ def test_clean_df_multilingual():
         }
     )
     token_filters = {"is_stop", "is_measure", "is_datetime", "like_url", "like_email", "is_username", "is_hashtag"}
+    tokenizer = MultilingualTokenizer(stopwords_folder_path=stopwords_folder_path)
+    for lang in input_df.language.values.tolist():
+        tokenizer.spacy_nlp_dict[lang] = tokenizer._create_spacy_tokenizer(lang)
+        tokenizer._activate_components_to_lemmatize(lang)
     text_cleaner = TextCleaner(
-        tokenizer=MultilingualTokenizer(stopwords_folder_path=stopwords_folder_path),
+        tokenizer=tokenizer,
         token_filters=token_filters,
         lemmatization=True,
         lowercase=False,


### PR DESCRIPTION
This PR updates spaCy to version 3.

Some of the changes:
- Adapted the new Tokenizer from https://github.com/dataiku/dss-plugin-nlp-analysis/blob/5b8c852403be32c6a99866577f1a16d72cc9d308/python-lib/nlp/spacy_tokenizer.py
- Updated all requirements to https://github.com/dataiku/dss-plugin-nlp-analysis/blob/5b8c852403be32c6a99866577f1a16d72cc9d308/code-env/python/spec/requirements.txt
- Updated the tokenizer handling in the tests (optionally we can also add some of the tests from https://github.com/dataiku/dss-plugin-nlp-analysis/blob/91464148cade2034f0082dc5c306d0ccacb1ca9f/tests/python/unit/test_spacy_tokenizer.py)
- Made sure Chinese default tokenization is using jieba (Else it will only use character segmentation)