### PR TITLE
Fix python3.9+ DataFrameParallelizer.run

### DIFF
--- a/core/parallelizer/parallelizer.py
+++ b/core/parallelizer/parallelizer.py
@@ -301,7 +301,7 @@ class DataFrameParallelizer:
             for batch in chunked(df_row_generator, self.batch_size):
                 futures.append(
                     pool.submit(
-                        fn=self._apply_function_with_error_logging,
+                        self._apply_function_with_error_logging,
                         batch=batch,
                         **pool_kwargs,
                     )


### PR DESCRIPTION
python3.8 introduced positional-only parameters. In python3.9 the `Executor.submit` method has changed so that `fn` is positional only. That means that this parameter can no longer be named and triggers a runtime `TypeError` exception.